### PR TITLE
Fixed wrong version path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def version(root_path):
     ---------
     https://packaging.python.org/guides/single-sourcing-package-version/
     """
-    version_path = root_path.joinpath('tensorly_lab', '__init__.py')
+    version_path = root_path.joinpath('tlab', '__init__.py')
     with version_path.open() as f:
         version_file = f.read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",


### PR DESCRIPTION
The install file assumed that the package is named `tensorly_lab`, but it is named `tlab`. This pull request fixes that (assuming that we want to keep the `tlab` path)